### PR TITLE
Extract only latest release block for GitHub release body

### DIFF
--- a/.github/workflows/Windows_release.yml
+++ b/.github/workflows/Windows_release.yml
@@ -90,6 +90,16 @@ jobs:
     - name: Push Packages to NuGet
       run: dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg" -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 
+    - name: "Extract latest release notes"
+      shell: pwsh
+      run: |
+        $content = Get-Content ${{ github.workspace }}/artifacts/RELEASE_NOTES.md -Raw
+        if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+          $Matches[1].Trim() | Set-Content ${{ github.workspace }}/artifacts/RELEASE_NOTES_LATEST.md
+        } else {
+          $content | Set-Content ${{ github.workspace }}/artifacts/RELEASE_NOTES_LATEST.md
+        }
+
     - name: Create GitHub Release
       id: create_release
       uses: actions/create-release@v1
@@ -98,7 +108,7 @@ jobs:
       with:
         tag_name: ${{ github.ref }}
         release_name: 'Akka.Cluster.Chunking v${{ github.ref_name }}'
-        body_path: ${{ github.workspace }}/artifacts/RELEASE_NOTES.md # Use note from artifact
+        body_path: ${{ github.workspace }}/artifacts/RELEASE_NOTES_LATEST.md # Use note from artifact
         draft: false
         prerelease: false
 


### PR DESCRIPTION
## Summary
- GitHub releases were using the entire RELEASE_NOTES.md, causing every release to contain the full changelog
- Added PowerShell step to extract only the first #### block into RELEASE_NOTES_LATEST.md
- Release action now uses RELEASE_NOTES_LATEST.md instead of the full file